### PR TITLE
5.x fixes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 10), linux-headers, gcc, make, rsync
 Standards-Version: 3.7.3.x
 Homepage: https://github.com/snuf/iomemory-vsl
 
-Package: iomemory-vsl-5.0.0-37-generic
+Package: iomemory-vsl-5.3.0-42-generic
 Architecture: amd64
 Provides: iomemory-vsl,
           iomemory-vsl-${fio-version}
@@ -15,7 +15,7 @@ Replaces: iodrive-driver, fio-driver
 Description: Modified driver for FIO devices
  Modified driver for FIO devices
 
-Package: iomemory-vsl-config-5.0.0-37-generic
+Package: iomemory-vsl-config-5.3.0-42-generic
 Architecture: amd64
 Provides: iomemory-vsl-config,
           iomemory-vsl-config-${fio-version}

--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.3.0-42-generic"
-PREV_KERNEL_SRC="/lib/modules/5.3.0-42-generic/build"
+PREV_KERNELVER="5.3.0-45-generic"
+PREV_KERNEL_SRC="/lib/modules/5.3.0-45-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/kfile.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfile.c
@@ -318,6 +318,9 @@ void kfio_set_file_ops_release_handler(fusion_file_operations_t *fops, void *rel
    our way through it by just pretending we're dumb deaf and blind, and reuse
    the botched allocated memory that was there before
 */
+void kfio_set_file_ops_owner(fusion_file_operations_t *fops, void *owner)
+{
+}
 
 void kfio_set_file_ops_llseek_handler(fusion_file_operations_t *pops, void *llseek)
 {

--- a/root/usr/src/iomemory-vsl-3.2.16/kfio.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfio.c
@@ -76,7 +76,7 @@ typedef struct FUSION_STRUCT_ALIGN(8) _linux_spinlock
 
 void *kfio_ioremap_nocache (unsigned long offset, unsigned long size)
 {
-    return ioremap_nocache(offset, size);
+    return ioremap(offset, size);
 }
 
 void  kfio_iounmap(void *addr)

--- a/root/usr/src/iomemory-vsl-3.2.16/kfio_config_add.sh
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfio_config_add.sh
@@ -23,6 +23,7 @@ KFIOC_X_HAS_DISK_STATS_NSECS
 KFIOC_X_HAS_COARSE_REAL_TS
 KFIOC_X_HAS_ELEVATOR_INIT
 KFIOC_X_PART0_HAS_IN_FLIGHT
+KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS
 "
 
 ##
@@ -82,6 +83,30 @@ void kfioc_test_request_queue_has_queue_lock_pointer(void) {
 '
 
     kfioc_test "$test_code" "$test_flag" 1
+}
+
+# flag:           KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS
+# usage:          undef for automatic selection by kernel version
+#                 0     if the kernel does not have the proc_create_data function
+#                 1     if the kernel has the function
+# description:    Between 5.3 and 5.6 the 4th option for proc_create_data changes.
+#                 It went from a "const struct file_operations *" to a
+#                 const struct proc_ops *.
+#                 https://elixir.bootlin.com/linux/v5.3/source/include/linux/proc_fs.h#L44
+#                 https://elixir.bootlin.com/linux/v5.6.3/source/include/linux/proc_fs.h#L59
+KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/proc_fs.h>
+
+void *kfioc_has_proc_create_data(struct inode *inode)
+{
+    const struct proc_ops *pops;
+    return proc_create_data(NULL, 0, NULL, pops, NULL);
+}
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror-implicit-function-declaration
 }
 
 # flag:           KFIOC_X_PART_STAT_REQUIRES_CPU

--- a/root/usr/src/iomemory-vsl-3.2.16/kinfo.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kinfo.c
@@ -26,6 +26,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //-----------------------------------------------------------------------------
 
+#include "port-internal.h"
 #include <linux/module.h>
 
 #include <fio/port/fio-port.h>

--- a/root/usr/src/iomemory-vsl-3.2.16/kinfo.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kinfo.c
@@ -397,18 +397,21 @@ static int kfio_info_seqf_open(fusion_inode *inode, fusion_file *file)
  */
 static void kfio_info_os_init(void)
 {
-    /* Initialize file ops used to handle fixed types. */
+#if ! KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS
     kfio_set_file_ops_owner(&kfio_info_type_fops, THIS_MODULE);
+    kfio_set_file_ops_owner(&kfio_info_seqf_fops, THIS_MODULE);
+    kfio_set_file_ops_owner(&kfio_info_text_fops, THIS_MODULE);
+#endif /* ! KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS */
+
+    /* Initialize file ops used to handle fixed types. */
     kfio_set_file_ops_write_handler(&kfio_info_type_fops, kfio_info_os_type_write);
     kfio_set_file_ops_read_handler (&kfio_info_type_fops, kfio_info_os_type_read);
 
-    kfio_set_file_ops_owner(&kfio_info_seqf_fops, THIS_MODULE);
     kfio_set_file_ops_open_handler   (&kfio_info_seqf_fops, kfio_info_seqf_open);
     kfio_set_file_ops_read_handler   (&kfio_info_seqf_fops, kfio_seq_read);
     kfio_set_file_ops_llseek_handler (&kfio_info_seqf_fops, kfio_seq_lseek);
     kfio_set_file_ops_release_handler(&kfio_info_seqf_fops, kfio_seq_release);
 
-    kfio_set_file_ops_owner(&kfio_info_text_fops, THIS_MODULE);
     kfio_set_file_ops_open_handler   (&kfio_info_text_fops, kfio_info_text_open);
     kfio_set_file_ops_read_handler   (&kfio_info_text_fops, kfio_seq_read);
     kfio_set_file_ops_llseek_handler (&kfio_info_text_fops, kfio_seq_lseek);

--- a/root/usr/src/iomemory-vsl-3.2.16/license.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/license.c
@@ -1,2 +1,3 @@
 #include "linux/module.h"
 MODULE_LICENSE("GPL");
+MODULE_VERSION("e76c2f2");

--- a/root/usr/src/iomemory-vsl-3.2.16/license.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/license.c
@@ -1,3 +1,3 @@
 #include "linux/module.h"
 MODULE_LICENSE("GPL");
-MODULE_VERSION("e76c2f2");
+MODULE_VERSION("8d44c50");

--- a/root/usr/src/iomemory-vsl-3.2.16/pci.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/pci.c
@@ -425,7 +425,7 @@ static uint8_t find_slot_number_bios(const struct pci_dev *dev)
     const uint8_t *stop_addr;
     void *bios_addr;
 
-    bios_addr = ioremap_nocache(BIOS_MEMORY_ADDRESS, BIOS_MEMORY_LEN);
+    bios_addr = ioremap(BIOS_MEMORY_ADDRESS, BIOS_MEMORY_LEN);
     if (bios_addr == NULL)
     {
         errprint("%s: could not map bios\n", pci_name((struct pci_dev*)dev));


### PR DESCRIPTION
Fixes compile issues for 5.5 and 5.6. Using proc_ops instead of file_operations where applicable, and trade ioremap_nocache for ioremap. Tests ran successful without issues on 5.6.4