### PR TITLE
V5.8.0

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/Makefile
+++ b/root/usr/src/iomemory-vsl-3.2.16/Makefile
@@ -61,6 +61,7 @@ TARGET ?= $(FIOARCH)_cc$(CCMAJOR)$(CCMINOR)
 
 KFIO_LIB ?= kfio/$(TARGET)_libkfio.o_shipped
 LAST_KFIO_LIB := $(shell ls -1 kfio | grep $(LAST_REAL_CCVER) | sort | tail -1)
+KFIO_LIB_CMD ?= kfio/.$(TARGET)_libkfio.o.cmd
 
 NCPUS:=$(shell grep -c ^processor /proc/cpuinfo)
 
@@ -79,6 +80,7 @@ check_n_fix_kfio_ccver:
 			cp kfio/${LAST_KFIO_LIB} ${KFIO_LIB}; \
 		fi \
 	fi
+	$(shell touch ${KFIO_LIB_CMD})
 
 clean modules_clean:
 	$(MAKE) \

--- a/root/usr/src/iomemory-vsl-3.2.16/Makefile
+++ b/root/usr/src/iomemory-vsl-3.2.16/Makefile
@@ -133,7 +133,7 @@ rpm:
 		cd $(shell git rev-parse --show-toplevel) && \
 			$(MAKE) rpm
 
-modules modules_install: check_n_fix_kfio_ccver check_target_kernel include/fio/port/linux/kfio_config.h add_module_version
+modules modules_install: check_target_kernel check_n_fix_kfio_ccver include/fio/port/linux/kfio_config.h add_module_version
 	$(MAKE) \
     -j$(NCPUS) \
 	-C $(KERNEL_BUILD) \

--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.8.0-rc7"
-PREV_KERNEL_SRC="/lib/modules/5.8.0-rc7/build"
+PREV_KERNELVER="5.3.0-64-generic"
+PREV_KERNEL_SRC="/lib/modules/5.3.0-64-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.3.0-59-generic"
-PREV_KERNEL_SRC="/lib/modules/5.3.0-59-generic/build"
+PREV_KERNELVER="5.8.0-rc7"
+PREV_KERNEL_SRC="/lib/modules/5.8.0-rc7/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/include/fio/port/common-linux/kflux.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/fio/port/common-linux/kflux.h
@@ -1,0 +1,16 @@
+/*
+ * <insert license>
+ */
+
+#ifndef __FUSION_LINUX_KERNEL_FLUX_H__
+#define __FUSION_LINUX_KERNEL_FLUX_H__
+
+#include <fio/port/kfio_config.h>
+
+#if KFIOC_X_HAS_MMAP_LOCK
+#define MMAP_LOCK_SEM mmap_lock
+#else /* ! KFIOC_X_HAS_MMAP_LOCK */
+#define MMAP_LOCK_SEM mmap_sem
+#endif /* KFIOC_X_HAS_MMAP_LOCK */
+
+#endif /* __FUSION_LINUX_KERNEL_FLUX_H__ */

--- a/root/usr/src/iomemory-vsl-3.2.16/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfio_config.sh
@@ -77,6 +77,7 @@ KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS
 KFIOC_X_TASK_HAS_CPUS_MASK
 KFIOC_X_LINUX_HAS_PART_STAT_H
 KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
+KFIOC_X_HAS_MMAP_LOCK
 "
 
 
@@ -96,7 +97,31 @@ done
 #
 # Actual test procedures for determining Kernel capabilities
 #
+##
+## Newly added tests HAVE to contain the kernel version it appeared in and an
+## LWN reference where the change in the kernel is and some form of reference
+## to documentation describing the change in the kernel.
+##
 ####
+# flag:            KFIOC_X_HAS_MMAP_LOCK
+# usage:           0   Kernels that do have mmap_lock
+#                  1   Kernels that don't have mmap_lock
+# kernel_version:  In 5.8 mmap_sem is removed from mm, and is moved to the new mmap_lock API
+# lwn_reference:   https://lwn.net/Articles/816059/
+# doc_reference:   https://linuxplumbersconf.org/event/4/contributions/556/attachments/304/509/fine_grained_mm.pdf
+KFIOC_X_HAS_MMAP_LOCK()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,8,0)
+    #error Kernel older than 5.8.0 no mmap_lock in mm
+#endif
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror
+}
+
 # flag:            KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
 # usage:           1   Kernels that do have blk_alloc_queue_node
 #                  0   Kernels that don't have blk_alloc_queue_node
@@ -215,6 +240,7 @@ update_timeout()
 open_log()
 {
     FIFO_DIR=$CONFIGDIR
+    FIFO_DIR=/tmp/
     # The tee processes will die when this process exits.
     rm -f "$FIFO_DIR/kfio_config.stdout" "$FIFO_DIR/kfio_config.stderr" "$FIFO_DIR/kfio_config.log"
     exec 3>&1 4>&2

--- a/root/usr/src/iomemory-vsl-3.2.16/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfio_config.sh
@@ -240,7 +240,6 @@ update_timeout()
 open_log()
 {
     FIFO_DIR=$CONFIGDIR
-    FIFO_DIR=/tmp/
     # The tee processes will die when this process exits.
     rm -f "$FIFO_DIR/kfio_config.stdout" "$FIFO_DIR/kfio_config.stderr" "$FIFO_DIR/kfio_config.log"
     exec 3>&1 4>&2

--- a/root/usr/src/iomemory-vsl-3.2.16/kmem.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kmem.c
@@ -200,9 +200,9 @@ int kfio_get_user_pages(fusion_user_page_t *pages, int nr_pages, fio_uintptr_t s
 {
     int retval;
 
-    down_read(&current->mm->mmap_sem);
+    down_read(&current->mm->MMAP_LOCK_SEM);
     retval =  get_user_pages(start, nr_pages, GET_USER_PAGES_FLAGS(write, 0), (struct page **) pages, NULL);
-    up_read(&current->mm->mmap_sem);
+    up_read(&current->mm->MMAP_LOCK_SEM);
     return retval;
 }
 

--- a/root/usr/src/iomemory-vsl-3.2.16/port-internal.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/port-internal.h
@@ -59,6 +59,7 @@
 
 #include <fio/port/common-linux/kassert.h>
 #include <fio/port/common-linux/commontypes.h>
+#include <fio/port/common-linux/kflux.h>
 #include <fio/port/kfio_config.h>
 #include <linux/blkdev.h>
 #include <linux/cdev.h>


### PR DESCRIPTION
1. First Macro based patch with kflux.h. Adopting to use macros to inject/modify code behavior based on tests. We're going to have to see how we make this work out for multiple lines though, or rather multiple blocks. The idea is to prevent weird chunks of nested stuff. For the use-case of arguments and single line or partial single line changes it seems to work nicely for now.

2. Fixes mmap_sem to mmap_lock move in 5.8.0 kernels

3. Fix order of check_target_kernel and check_n_fix_kfio_ccver. The check_target_kernel forces a make clean, so when the .cmd file gets touched by check_n_fix_kfio_ccver before the clean it disappears with the clean. The missing .cmd file became an issue in 5.8.0, as the MODPOST warning for a missing .cmd file for the x86_64_ccXX_libkfio.o_shipped file is now an ERROR and breaks the linking.