### PR TITLE
Disable rpmbuild fail on unpackaged build files

### DIFF
--- a/fio-driver.spec
+++ b/fio-driver.spec
@@ -29,6 +29,9 @@
 # Turn off silly debug packages
 %define debug_package %{nil}
 
+# Turn off fail on unpackaged files
+%define _unpackaged_files_terminate_build 0
+
 
 Summary: Driver for SanDisk Fusion ioMemory devices
 Name: iomemory-vsl


### PR DESCRIPTION
rpmbuild failes because of unpackaged files:
e.g 
```
rpmbuild -bb fio-driver.spec
...
RPM build errors:
    Macro expanded in comment on line 41: %{name}-%{fio_tar_version}.tar.gz

    Macro expanded in comment on line 41: %{name}-%{fio_tar_version}.tar.gz

    Installed (but unpackaged) file(s) found:
   /usr/src/iomemory-vsl-3.2.16/.cdev.o.cmd
   /usr/src/iomemory-vsl-3.2.16/.driver_init.o.cmd
   /usr/src/iomemory-vsl-3.2.16/.errno.o.cmd
   /usr/src/iomemory-vsl-3.2.16/.iomemory-vsl.ko.cmd
...
```