### PR TITLE
5.11 support

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.4.0-59-generic"
-PREV_KERNEL_SRC="/lib/modules/5.4.0-59-generic/build"
+PREV_KERNELVER="5.8.0-44-generic"
+PREV_KERNEL_SRC="/lib/modules/5.8.0-44-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.8.0-44-generic"
-PREV_KERNEL_SRC="/lib/modules/5.8.0-44-generic/build"
+PREV_KERNELVER="5.4.0-65-generic"
+PREV_KERNEL_SRC="/lib/modules/5.4.0-65-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
@@ -27,5 +27,11 @@
   #define BLK_ALLOC_QUEUE blk_alloc_queue(node);
   #define BLK_QUEUE_SPLIT blk_queue_split(&bio);
 #endif /* KFIOC_X_HAS_MAKE_REQUEST_FN */
-
+#if KFIOC_X_GENHD_PART0_IS_A_POINTER
+  #define GD_PART0 gd->part0
+  #define GET_BDEV disk->gd->part0
+#else /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
+  #define GD_PART0 &gd->part0
+  #define GET_BDEV bdget_disk(disk->gd, 0);
+#endif /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
 #endif /* __FIO_KBLOCK_META_H__ */

--- a/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
@@ -29,7 +29,7 @@
 #endif /* KFIOC_X_HAS_MAKE_REQUEST_FN */
 #if KFIOC_X_GENHD_PART0_IS_A_POINTER
   #define GD_PART0 gd->part0
-  #define GET_BDEV disk->gd->part0
+  #define GET_BDEV bdgrab(disk->gd->part0)
 #else /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
   #define GD_PART0 &gd->part0
   #define GET_BDEV bdget_disk(disk->gd, 0);

--- a/root/usr/src/iomemory-vsl-3.2.16/kblock.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kblock.c
@@ -419,7 +419,7 @@ void kfio_destroy_disk(kfio_disk_t *disk, destroy_type_t dt)
     {
         struct block_device *bdev;
 
-        bdev = bdget_disk(disk->gd, 0);
+        bdev = GET_BDEV;
 
         if (bdev != NULL)
         {
@@ -508,9 +508,9 @@ void kfio_disk_stat_write_update(kfio_disk_t *fgd, uint64_t totalsize, uint64_t 
     {
         struct gendisk *gd = fgd->gd;
         part_stat_lock();
-        part_stat_inc(&gd->part0, ios[1]);
-        part_stat_add(&gd->part0, sectors[1], totalsize >> 9);
-	      part_stat_add(&gd->part0, nsecs[1],   duration * 1000);
+        part_stat_inc(GD_PART0, ios[1]);
+        part_stat_add(GD_PART0, sectors[1], totalsize >> 9);
+	      part_stat_add(GD_PART0, nsecs[1],   duration * 1000);
         part_stat_unlock();
     }
 }
@@ -521,9 +521,9 @@ void kfio_disk_stat_read_update(kfio_disk_t *fgd, uint64_t totalsize, uint64_t d
     {
         struct gendisk *gd = fgd->gd;
         part_stat_lock();
-        part_stat_inc(&gd->part0, ios[0]);
-        part_stat_add(&gd->part0, sectors[0], totalsize >> 9);
-        part_stat_add(&gd->part0, nsecs[0],   duration * 1000);
+        part_stat_inc(GD_PART0, ios[0]);
+        part_stat_add(GD_PART0, sectors[0], totalsize >> 9);
+        part_stat_add(GD_PART0, nsecs[0],   duration * 1000);
         part_stat_unlock();
     }
 }
@@ -532,7 +532,7 @@ void kfio_disk_stat_read_update(kfio_disk_t *fgd, uint64_t totalsize, uint64_t d
 int kfio_get_gd_in_flight(kfio_disk_t *fgd, int rw)
 {
     struct gendisk *gd = fgd->gd;
-    return part_stat_read(&gd->part0, ios[STAT_WRITE]);
+    return part_stat_read(GD_PART0, ios[STAT_WRITE]);
 }
 
 void kfio_set_gd_in_flight(kfio_disk_t *fgd, int rw, int in_flight)
@@ -542,7 +542,7 @@ void kfio_set_gd_in_flight(kfio_disk_t *fgd, int rw, int in_flight)
 
     if (use_workqueue != USE_QUEUE_RQ)
     {
-        part_stat_set_all(&gd->part0, in_flight);
+        part_stat_set_all(GD_PART0, in_flight);
     }
 }
 

--- a/root/usr/src/iomemory-vsl-3.2.16/ktime.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/ktime.c
@@ -30,7 +30,7 @@
 #include <fio/port/ktime.h>
 
 #include <linux/jiffies.h>
-#include <linux/time.h>
+#include <linux/timekeeping.h>
 #include <linux/delay.h>
 #ifndef __KERNEL__
 #include <unistd.h>
@@ -107,7 +107,9 @@ int noinline fusion_HZ(void)
  */
 uint32_t noinline kfio_get_seconds(void)
 {
-    return get_seconds();
+    // this hurts...till we can patch the binary .so we just do this
+    // means we are toast in 2038 though....
+    return (uint32_t) ktime_get_real_seconds();
 }
 
 /**

--- a/root/usr/src/iomemory-vsl-3.2.16/module_operations.sh
+++ b/root/usr/src/iomemory-vsl-3.2.16/module_operations.sh
@@ -36,6 +36,7 @@ dkms_install() {
 
 get_rel_ver() {
     version=$1
+    kname=$(uname -r)
     release=$(git describe --tag)
     if [ "$version" == "" ]; then
         tag=$(git rev-parse --short HEAD)
@@ -43,10 +44,10 @@ get_rel_ver() {
     if [ "$version" == "" -a "$release" == "" ]; then
         echo "Error: not a release and no git tag, aborting."
         exit 1
+    elif [ "$version" != "" ]; then
+        echo ${kname%-*}-${version}
     elif [ "$release" != "" ]; then
         echo $release
-    elif [ "$version" != "" ]; then
-        echo $version
     else
         echo "deadbeef"
     fi


### PR DESCRIPTION
* In 5.11 the gendisk part becomes a pointer and also a block_device, which causes two changes in the code. These are reflected by two defines in block_meta.h.
* Make sure we can build on sshfs, move the fifo to /tmp
* Move to timekeeping.h instead of time.h. Main snag here is that we are limited to 32bits due to the libkfio.h at the moment. This has to move to 64 bits before 2038.
* Adding kernel name to version