### PR TITLE
5.12 support

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.4.0-65-generic"
-PREV_KERNEL_SRC="/lib/modules/5.4.0-65-generic/build"
+PREV_KERNELVER="5.11.0-16-generic"
+PREV_KERNEL_SRC="/lib/modules/5.11.0-16-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
@@ -11,6 +11,12 @@
 #include <linux/part_stat.h>
 #endif /* KFIOC_X_LINUX_HAS_PART_STAT_H */
 
+#if KFIOC_X_BIO_HAS_BI_BDEV
+  #define BIO_DISK bi_bdev->bd_disk
+#else /* KFIOC_X_BIO_HAS_BI_BDEV */
+  #define BIO_DISK bi_disk
+#endif /* KFIOC_X_BIO_HAS_BI_BDEV */
+
 #if KFIOC_X_HAS_MAKE_REQUEST_FN
   static unsigned int kfio_make_request(struct request_queue *queue, struct bio *bio);
   #define BLK_QUEUE_SPLIT blk_queue_split(queue, &bio);

--- a/root/usr/src/iomemory-vsl-3.2.16/kblock.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kblock.c
@@ -1119,7 +1119,7 @@ blk_qc_t kfio_submit_bio(struct bio *bio)
 #define FIO_MFN_RET 0
 {
 #if ! KFIOC_X_HAS_MAKE_REQUEST_FN
-    struct request_queue *queue = bio->bi_disk->queue;
+    struct request_queue *queue = bio->BIO_DISK->queue;
 #endif
     struct kfio_disk *disk = queue->queuedata;
     void *plug_data;

--- a/root/usr/src/iomemory-vsl-3.2.16/ktime.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/ktime.c
@@ -132,14 +132,8 @@ KFIO_EXPORT_SYMBOL(fusion_getmicrotime);
 /// @brief return current UTC wall clock time in seconds since the Unix epoch (Jan 1 1970).
 uint64_t noinline fusion_getwallclocktime(void)
 {
-#if KFIOC_X_HAS_COARSE_REAL_TS
     struct timespec64 ts;
-
     ktime_get_coarse_real_ts64(&ts);
-#else
-    struct timespec ts = current_kernel_time();
-#endif
-
     return (uint64_t)ts.tv_sec;
 }
 


### PR DESCRIPTION
Adds KFIOC_X_BIO_HAS_BI_BDEV for 5.12, where bi_disk has moved to bi_bdev->bd_bdisk.
Removes KFIOC_X_HAS_COARSE_REAL_TS as we don't care about pre 5.0
getting rid of KFIOC_X_HAS_MAKE_REQUEST_FN is trickier than it seems, so leaving that for now.