### PR TITLE
fix fstrim and discard issues after 5.9 fixes

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/kblock.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kblock.c
@@ -335,6 +335,7 @@ int kfio_create_disk(struct fio_device *dev, kfio_pci_dev_t *pdev, uint32_t sect
         blk_queue_flag_set(QUEUE_FLAG_DISCARD, rq);
         // XXXXXXX !!! WARNING - power of two sector sizes only !!! (always true in standard linux)
         blk_queue_max_discard_sectors(rq, (UINT_MAX & ~((unsigned int) sector_size - 1)) >> 9);
+        rq->limits.discard_granularity = sector_size;
     }
 
     blk_queue_flag_set(QUEUE_FLAG_WC, rq);


### PR DESCRIPTION
The vsl4 driver seems to set discard granularity, which the vsl driver never did. However moving to kfio_submit seems to have made this mandatory. This wasn't caught because the tests didn't trigger fstrim and discard wasn't set.  Happy @bplein found this issue :)