### PR TITLE
fix: move declaration to top of kfio_copy_to_user (ISO C90)

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/kfio_common.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kfio_common.c
@@ -266,10 +266,10 @@ KFIO_EXPORT_SYMBOL(kfio_copy_from_user);
 
 int kfio_copy_to_user(void *to, const void *from, unsigned len)
 {
+    int result = -EINVAL;
     if (sure_erase_mode == 0) {
         return copy_to_user(to, from, len);
     }
-    int result = -EINVAL;
     if (!from || !to) {
         errprint("sure_erase_mode: NULL pointer passed to kfio_copy_from_user\n");
         return result;


### PR DESCRIPTION
Building against kernel headers that compile with -std=gnu89 (e.g. Ubuntu 5.15.0-174-generic) fails with -Werror=declaration-after-statement:

    kfio_common.c:272:5: error: ISO C90 forbids mixed declarations and code
      272 |     int result = -EINVAL;

The kernel build enables -Wdeclaration-after-statement and the driver Kbuild appends -Werror, so any mixed decl-after-code aborts the build.

In kfio_copy_to_user() the `int result = -EINVAL;` declaration sat *after* the early-return `if (sure_erase_mode == 0)` block, which is a statement, violating ISO C90. Older kernels (6.x) compile with a newer C standard and silently accept it; 5.15's build does not.

Fix: hoist `int result = -EINVAL;` to the top of the function, matching the pattern already used in the sibling kfio_copy_from_user() (where the same class of bug was fixed in PR #150 / iso-c90-fix but this second copy was missed).