### PR TITLE
7 kernel checks numa node_id and is not happy if it's not actually there

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl-3.2.16/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="6.14.0-28-generic"
-PREV_KERNEL_SRC="/lib/modules/6.14.0-28-generic/build"
+PREV_KERNELVER="6.17.0-8-generic"
+PREV_KERNEL_SRC="/lib/modules/6.17.0-8-generic/build"

--- a/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
@@ -25,11 +25,11 @@
 
 #if KFIOC_X_BLK_ALLOC_DISK_EXISTS
   #define BLK_ALLOC_QUEUE dp->gd->queue;
-  #define BLK_ALLOC_DISK blk_alloc_disk(FIO_NUM_MINORS);
+  #define BLK_ALLOC_DISK blk_alloc_disk(NUMA_NO_NODE);
   #define BLK_MQ_ALLOC_QUEUE blk_mq_init_queue(&disk->tag_set);
 #elif KFIOC_X_BLK_ALLOC_DISK_HAS_QUEUE_LIMITS
   #define BLK_ALLOC_QUEUE dp->gd->queue;
-  #define BLK_ALLOC_DISK blk_alloc_disk(NULL, FIO_NUM_MINORS);
+  #define BLK_ALLOC_DISK blk_alloc_disk(NULL, NUMA_NO_NODE);
   #define BLK_MQ_ALLOC_QUEUE blk_mq_alloc_queue(&disk->tag_set, NULL, NULL);
 #else /* KFIOC_X_BLK_ALLOC_DISK_EXISTS */
   #if KFIOC_X_HAS_MAKE_REQUEST_FN != 1


### PR DESCRIPTION
blk_alloc_disk always took the node_id. We incorrectly passed the value that alloc_disk required, my bad. Due to a change in Kernel 7 putting an invalid node_id behaves different and surfaces this mistake.

Thanks @alwilson