### PR TITLE
[Fix] Always validate bios against queue limits before submit

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl-3.2.16/include/kblock_meta.h
@@ -50,7 +50,8 @@
 #if KFIOC_X_HAS_MAKE_REQUEST_FN
   static unsigned int kfio_make_request(struct request_queue *queue, struct bio *bio);
   #define KFIO_SUBMIT_BIO_RC return FIO_MFN_RET;
-  #define BLK_QUEUE_SPLIT blk_queue_split(queue, &bio);
+  #define KFIO_BIO_SPLIT_TO_LIMITS_OR_RETURN \
+    do { blk_queue_split(queue, &bio); } while (0)
 
   #if KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
     #define BLK_ALLOC_QUEUE blk_alloc_queue_node(GFP_NOIO, node);
@@ -66,14 +67,20 @@
     #define KFIO_SUBMIT_BIO_RC return FIO_MFN_RET;
   #else
     #define KFIO_SUBMIT_BIO void kfio_submit_bio(struct bio *bio)
-    #define KFIO_SUBMIT_BIO_RC
+    #define KFIO_SUBMIT_BIO_RC return;
   #endif /*KFIOC_X_SUBMIT_BIO_RETURNS_BLK_QC_T */
   KFIO_SUBMIT_BIO;
 
   #if KFIOC_X_BIO_SPLIT_TO_LIMITS
-    #define BLK_QUEUE_SPLIT bio = bio_split_to_limits(bio);
+    #define KFIO_BIO_SPLIT_TO_LIMITS_OR_RETURN \
+      do {                                     \
+        bio = bio_split_to_limits(bio);        \
+        if (!bio)                              \
+          KFIO_SUBMIT_BIO_RC                   \
+      } while (0)
   #else
-    #define BLK_QUEUE_SPLIT blk_queue_split(&bio);
+    #define KFIO_BIO_SPLIT_TO_LIMITS_OR_RETURN \
+      do { blk_queue_split(&bio); } while (0)
   #endif /* KFIOC_X_BIO_SPLIT_TO_LIMITS */
 #endif /* KFIOC_X_HAS_MAKE_REQUEST_FN */
 

--- a/root/usr/src/iomemory-vsl-3.2.16/kblock.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kblock.c
@@ -1139,15 +1139,14 @@ KFIO_SUBMIT_BIO
     struct kfio_disk *disk = queue->queuedata;
     void *plug_data;
 
+    KFIO_BIO_SPLIT_TO_LIMITS_OR_RETURN;
+
     if (bio_data_dir(bio) == WRITE && !holdoff_writes_under_pressure(disk))
     {
         kassert_once(!"timed out waiting for queue to unstall.");
         __kfio_bio_complete(bio, 0, -EIO);
 	KFIO_SUBMIT_BIO_RC
     }
-
-    if (bio_segments(bio) >= queue_max_segments(queue))
-        BLK_QUEUE_SPLIT;
 
     // iomemory-vsl4 has atom bio here
 


### PR DESCRIPTION
ioDrive DMA descriptors require 64-bit aligned addresses and lengths, but the block path currently submits mapped bios without validating the final DMA segments handed to the device.

 On newer kernels, direct-I/O requests can reach the driver with bio segments that violate that hardware requirement even when the overall request size is sector aligned. In that case, the device reports `Unaligned DMA addr` and may later hit the watchdog path and transition to read-only mode.

 Validate the mapped DMA segments after DMA mapping and reject requests whose address or length is not 8-byte aligned before they are submitted to the device. Apply the guard in both the immediate and plugged submission paths.

This prevents malformed bios from reaching hardware while preserving normal behavior for aligned I/O.

Test: Verified VM boot without errors after `DKMS` build and SATA passthrough.
Closes: #153, #155