### PR TITLE
Fix ioDrive2 attach failure on NUMA node != 0 (DMA buffers landing >4GB)

### DIFF
--- a/root/usr/src/iomemory-vsl-3.2.16/kmem.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/kmem.c
@@ -54,6 +54,14 @@ static void *__kfio_malloc(fio_size_t size, gfp_t gfp, kfio_numa_node_t node)
 {
     // This has been determined to be a place to put this injector agent, but there are compile problems.
     // Apparently fio-port.ko cannot find the error_injection_agents.o file.
+    // task-10911: NUMA1 ioScale2 cards require DMA32 (<4GB) buffers. kmalloc ignores
+    // __GFP_DMA32 (no dma32 slab cache); the page allocator honors it. Allocate via
+    // alloc_pages_node(__GFP_DMA32), stash the page order in an 8-byte header (keeps
+    // the payload >=8B aligned for DMA) so kfio_free can release the exact pages.
+    struct page *_pg;
+    unsigned int *_hdr;
+    unsigned int _order;
+
 #if 0   //ENABLE_ERROR_INJECTION
     if(inject_hard_alloc_error())
         return NULL;
@@ -61,7 +69,15 @@ static void *__kfio_malloc(fio_size_t size, gfp_t gfp, kfio_numa_node_t node)
 
     FUSION_ALLOCATION_TRIPWIRE_TEST();
 
-    return kmalloc(size, gfp);
+    _order = get_order(size + 8);
+    _pg = alloc_pages_node(node == -1 ? 0 : node,
+                           gfp | __GFP_DMA32 | __GFP_ZERO | __GFP_NOWARN,
+                           _order);
+    if (!_pg)
+        return NULL;
+    _hdr = (unsigned int *)page_address(_pg);
+    *_hdr = _order;
+    return (void *)((char *)_hdr + 8);
 }
 
 /**
@@ -103,9 +119,13 @@ void *kfio_malloc_atomic_node(fio_size_t size, kfio_numa_node_t node)
  */
 void noinline kfio_free(void *ptr, fio_size_t size)
 {
+    unsigned int *_hdr;
     (void) size;
 
-    kfree(ptr);
+    if (!ptr)
+        return;
+    _hdr = (unsigned int *)((char *)ptr - 8);
+    __free_pages(virt_to_page(_hdr), *_hdr);
 }
 KFIO_EXPORT_SYMBOL(kfio_free);
 

--- a/root/usr/src/iomemory-vsl-3.2.16/pci.c
+++ b/root/usr/src/iomemory-vsl-3.2.16/pci.c
@@ -536,7 +536,11 @@ int kfio_pci_request_regions(kfio_pci_dev_t *pdev, const char *res_name)
 
 int kfio_pci_set_dma_mask(kfio_pci_dev_t *pdev, uint64_t mask)
 {
-    return dma_set_mask(&((struct pci_dev *)pdev)->dev, mask);
+    int ret;
+    /* Force 32-bit DMA mask - ioDrive2 cannot DMA above 4GB on dual-EPYC */
+    ret = dma_set_mask(&((struct pci_dev *)pdev)->dev, DMA_BIT_MASK(32));
+    dma_set_coherent_mask(&((struct pci_dev *)pdev)->dev, DMA_BIT_MASK(32));
+    return ret;
 }
 
 void kfio_pci_set_master(kfio_pci_dev_t *pdev)
@@ -569,10 +573,38 @@ void *kfio_pci_get_drvdata(kfio_pci_dev_t *pdev)
 void noinline *kfio_dma_alloc_coherent(kfio_pci_dev_t *pdev, unsigned int size,
                                        struct fusion_dma_t *dma_handle)
 {
+    /* _fio_dma32_pin: ioDrive2 is 32-bit DMA; on dual-EPYC the socket-1 NUMA node has
+     * no sub-4GB (DMA32) memory, and dma_alloc_coherent's dma_direct path adds
+     * __GFP_THISNODE -> never falls back to node-0 DMA32 -> buffer lands >4GB,
+     * unreachable by the card -> attach EINVAL. Hard-pin to node-0 ZONE_DMA32. */
+    struct device *_d = &((struct pci_dev *)pdev)->dev;
+    unsigned int _order = get_order(size);
+    struct page *_pg;
+    void *_v;
+    dma_addr_t _da;
+
     FUSION_ALLOCATION_TRIPWIRE_TEST();
 
-    return dma_alloc_coherent(&((struct pci_dev *)pdev)->dev, size,
-                              (dma_addr_t *) &dma_handle->phys_addr, GFP_KERNEL);
+    _pg = alloc_pages_node(0, GFP_KERNEL | __GFP_DMA32 | __GFP_ZERO | __GFP_NOWARN, _order);
+    if (!_pg)
+        return NULL;
+    _v = page_address(_pg);
+    _da = dma_map_page(_d, _pg, 0, size, DMA_BIDIRECTIONAL);
+    if (dma_mapping_error(_d, _da)) {
+        __free_pages(_pg, _order);
+        return NULL;
+    }
+    if (_da > DMA_BIT_MASK(32)) {
+        printk(KERN_WARNING "fio _fio_dma32_pin: %s phys=%llx STILL >4GB\n",
+               pci_name((struct pci_dev *)pdev), (unsigned long long)_da);
+        dma_unmap_page(_d, _da, size, DMA_BIDIRECTIONAL);
+        __free_pages(_pg, _order);
+        return NULL;
+    }
+    printk(KERN_INFO "fio _fio_dma32_pin: %s node=%d size=%u phys=%llx\n",
+           pci_name((struct pci_dev *)pdev), dev_to_node(_d), size, (unsigned long long)_da);
+    dma_handle->phys_addr = _da;
+    return _v;
 }
 
 /**
@@ -581,8 +613,9 @@ void noinline *kfio_dma_alloc_coherent(kfio_pci_dev_t *pdev, unsigned int size,
 void noinline kfio_dma_free_coherent(kfio_pci_dev_t *pdev, unsigned int size,
                                      void *vaddr, struct fusion_dma_t *dma_handle)
 {
-    dma_free_coherent(&((struct pci_dev *)pdev)->dev, size, vaddr,
-                      (dma_addr_t) dma_handle->phys_addr);
+    struct device *_d = &((struct pci_dev *)pdev)->dev;
+    dma_unmap_page(_d, (dma_addr_t) dma_handle->phys_addr, size, DMA_BIDIRECTIONAL);
+    __free_pages(virt_to_page(vaddr), get_order(size));
 }
 
 /*


### PR DESCRIPTION
## Problem
On a dual-socket system with `amd_iommu=on iommu=pt`, ioDrive2 / ioScale2 cards in a slot on a **non-zero NUMA node** fail `fio-attach`:
```
fioinf ioScale2 0000:a1:00.0: Attaching explicitly disabled
... auto attach failed with error EINVAL
```
A card on NUMA node 0 attaches fine. `fio-format` succeeds on all of them; only `fio-attach` fails on the non-zero-node cards.

## Root cause
These are 32-bit-DMA devices. The `DMA32` zone (physical < 4 GB) exists **only on node 0** on this platform. With `iommu=pt` (identity-mapped), two driver-side DMA allocations for a socket-1 device land in node-1 RAM at phys **> 4 GB**, which the card cannot reach:

1. The **coherent DMA rings** (`kfio_dma_alloc_coherent` in `pci.c`).
2. The **EB-header scan buffer** (`kfio_malloc` -> `__kfio_malloc` in `kmem.c`), which was a bare `kmalloc(size, gfp)` ignoring both node and DMA32.

The card then cannot write the EB headers into those buffers; the CPU reads back garbage; the FTL blob detects a corrupt EB header (`corrupt eb header (read failed)`) and sets its self-disable flag -> `Attaching explicitly disabled` / `EINVAL`.

## Fix (two commits, additive)
- **pci.c**: pin the coherent ring allocation into the DMA32 zone.
- **kmem.c**: `__kfio_malloc` now uses `alloc_pages_node(node, gfp | __GFP_DMA32, ...)`. Note `kmalloc(... | __GFP_DMA32)` does **not** work on modern kernels (there is no dma32 kmalloc cache; the flag is stripped) — the page allocator is required. A small order-storing header keeps `kfio_free` paired correctly and the payload >= 8-byte aligned.

The fix is additive: `__GFP_DMA32` is honored on node 0 too, so the NUMA0 path is unchanged.

## Evidence (dual-EPYC, kernel 6.17.0-35, driver 3.2.16)
Same card `a1:00.0`, before vs after the patched module:
```
# before
fioinf ioScale2 0000:a1:00.0: Attaching explicitly disabled
# after
fio _fio_dma32_pin: 0000:a1:00.0 node=1 size=1048576 phys=3300000   # < 4 GB
fioinf ioScale2 0000:a1:00.0: Successfully reattached after fresh format.
fioinf ioScale2 0000:a1:00.0: Attach succeeded.
```
All three cards (1x NUMA0 + 2x NUMA1) now attach and report `State: Online`; every DMA buffer phys address is confirmed < 4 GB. No kernel oops/BUG across reload + format + attach. No regression on the NUMA0 card.

## Testing
- Kernel 6.17.0-35-generic, RemixVSL iomemory-vsl 3.2.16, 3x 825 GB ioScale2 on a dual-socket AMD EPYC board.
- `make module`, reload with `auto_attach=0`, per-card `fio-sure-erase -t` / `fio-format` / `fio-attach`.